### PR TITLE
Reduce opacity of invisible characters

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -38,7 +38,7 @@ atom-text-editor.is-focused, atom-text-editor.is-focused::shadow {
 
 atom-text-editor .invisible-character,
 :host .invisible-character {
-  color: rgba(192, 197, 206, 0.3);
+  color: rgba(192, 197, 206, 0.1);
 }
 
 .variable.parameter.function {


### PR DESCRIPTION
Hello,

I really like your theme, but I have a small problem with invisible characters. They are hard to distinguish from comments:

![screenshot 2015-04-30 13 28 34](https://cloud.githubusercontent.com/assets/11627131/7411907/1b808dc8-ef3d-11e4-99e7-185d853583e1.png)

I'd propose reducing the opacity a bit:
![screenshot 2015-04-30 13 29 00](https://cloud.githubusercontent.com/assets/11627131/7411909/24fa9bc8-ef3d-11e4-93a4-a5718e78f896.png)
