### PR TITLE
Use gradient for line indicator

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -23,11 +23,10 @@ atom-text-editor, :host {
 
     .line-number {
       &.cursor-line {
-        background-color: @syntax-gutter-line-number;
+        background: -webkit-linear-gradient(left, @syntax-gutter-line-number-no-selection, @syntax-gutter-background-color);
       }
 
       &.cursor-line-no-selection {
-        background-color: @syntax-gutter-line-number-no-selection;
         color: @syntax-gutter-text-color-selected;
       }
     }


### PR DESCRIPTION
Hi @anson0370,

I changed the active-line indicator to use a gradient. It's a very subtle change:
![screenshot 2016-01-24 02 26 09](https://cloud.githubusercontent.com/assets/11627131/12533884/0f15c71e-c242-11e5-89c3-c2bf490b4346.png)![screenshot 2016-01-24 02 24 03](https://cloud.githubusercontent.com/assets/11627131/12533885/10f338dc-c242-11e5-9aa7-86a4527fe9a1.png)

Best wishes

Robert
